### PR TITLE
Switched to regexp2 for more complex regex.

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -3,9 +3,10 @@ package ght
 import (
 	"net/http"
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/dlclark/regexp2"
 )
 
 // ParseCSV takes a csv of the correct format and returns a slice of HTTPTest.
@@ -44,7 +45,7 @@ func ParseCSV(rawCSV *string, logger *VerboseLogger, retries, timeElapse, timeOu
 			tmpClient.ExpectedType = v
 		case 4:
 			if len(v) > 0 {
-				s, err := regexp.Compile(v)
+				s, err := regexp2.Compile(v, regexp2.Compiled)
 				if err != nil {
 					logger.Printf("Error parsing regular expression: %s\n", err)
 				} else {

--- a/csv_test.go
+++ b/csv_test.go
@@ -2,9 +2,9 @@ package ght_test
 
 import (
 	"net/http"
-	"regexp"
 	"testing"
 
+	"github.com/dlclark/regexp2"
 	"github.com/ramjac/ght"
 )
 
@@ -74,7 +74,7 @@ func TestParseCSV(t *testing.T) {
 						},
 					},
 					ExpectedStatus: 200,
-					Regex:          regexp.MustCompile("Goblet"),
+					Regex:          regexp2.MustCompile("Goblet", regexp2.Compiled),
 					ExpectMatch:    true,
 					Retries:        1,
 					TimeElapse:     1,

--- a/excel.go
+++ b/excel.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/dlclark/regexp2"
 	"github.com/tealeg/xlsx"
 )
 
@@ -73,7 +73,7 @@ func ImportExcel(fileName, tabsToTest *string, logger *VerboseLogger, retries, t
 					tmpClient.ExpectedType = strings.TrimSpace(v.Value)
 				case 7:
 					if len(v.Value) > 0 {
-						s, err := regexp.Compile(v.Value)
+						s, err := regexp2.Compile(v.Value, regexp2.Compiled)
 						if err != nil {
 							logger.Printf("Error parsing regular expression: %s\n", err)
 						} else {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,7 +1,10 @@
 package ght_test
 
-import "net/url"
-import "regexp"
+import (
+	"net/url"
+
+	"github.com/dlclark/regexp2"
+)
 
 func MustParseUrl(u string) *url.URL {
 	parsed, err := url.Parse(u)
@@ -13,8 +16,8 @@ func MustParseUrl(u string) *url.URL {
 	return parsed
 }
 
-func MustCompileRegex(input string) *regexp.Regexp {
-	r, err := regexp.Compile(input)
+func MustCompileRegex(input string) *regexp2.Regexp {
+	r, err := regexp2.Compile(input, regexp2.Compiled)
 
 	if err != nil {
 		panic(err)

--- a/request.go
+++ b/request.go
@@ -6,10 +6,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"reflect"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/dlclark/regexp2"
 )
 
 // HTTPTest is a request to be tested.
@@ -17,7 +18,7 @@ type HTTPTest struct {
 	Request                      *http.Request
 	ExpectedStatus               int
 	ExpectedType                 string
-	Regex                        *regexp.Regexp
+	Regex                        *regexp2.Regexp
 	ExpectMatch                  bool
 	Retries, TimeElapse, TimeOut int
 }
@@ -97,9 +98,9 @@ func (h *HTTPTest) checkRequest(logger *VerboseLogger) bool {
 				return false
 			}
 
-			m := h.Regex.MatchString(string(tmp[:]))
+			m, err := h.Regex.MatchString(string(tmp[:]))
 
-			if m != h.ExpectMatch {
+			if m != h.ExpectMatch || err != nil {
 				return false
 			}
 		}


### PR DESCRIPTION
In doing some testing, we noticed that the regex supported by Go's standard library is fairly limited in order to meet performance requirements. I'm switching GHT to a different regex parser with more features because features are more important than regex performance for this use case.